### PR TITLE
Fix Excel import dependency

### DIFF
--- a/OSIF 2.0.py
+++ b/OSIF 2.0.py
@@ -51,7 +51,13 @@ def import_xlsx_file(path):
     tuple of lists
         frequency, z_prime, z_double_prime, z_mod extracted from the file.
     """
-    df = pd.read_excel(path)
+    try:
+        df = pd.read_excel(path, engine="openpyxl")
+    except ImportError as exc:
+        raise ImportError(
+            "openpyxl is required to load Excel files. "
+            "Install it with 'pip install openpyxl' and try again."
+        ) from exc
     if "-Z'' (Ω)" in df.columns:
         df["Z'' (Ω)"] = -df.pop("-Z'' (Ω)")
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,15 @@
 Open Source Impedance Fitter (OSIF) is a program that allows the user to fit electrochemical impedance spectra of Proton-exchange membrane fuel cells collected under a hydrogen/nitrogen (anode/cathode) environment to an accepted quasi-transmission line model (1), or one dimentional linear diffusion or spherical diffusion models (2).
 
-To use OSIF, the following non-default python packages will have to be downloaded:
-  - pandas (uses openpyxl for Excel files)
+To use OSIF, the following non-default Python packages are required:
+  - pandas
+  - openpyxl  # needed to load Excel files
   - matplotlib
   - numpy
   - scipy
+
+A ``requirements.txt`` file is provided, so dependencies can be installed with::
+
+    pip install -r requirements.txt
 
 Version 2.0 now includes a helper function ``import_xlsx_file``
 to load Excel data outside of the GUI.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+pandas
+openpyxl
+matplotlib
+numpy
+scipy


### PR DESCRIPTION
## Summary
- add openpyxl exception handling when loading Excel files
- document new dependency and usage of `requirements.txt`
- provide a simple `requirements.txt`

## Testing
- `python -m py_compile 'OSIF 2.0.py'`
- `python -m pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6864b551c154832cbd7b6da3d19d94e0